### PR TITLE
modify the summary field and description filed, solve can’t be comple…

### DIFF
--- a/RJWebView.podspec
+++ b/RJWebView.podspec
@@ -2,9 +2,8 @@
 Pod::Spec.new do |s|
   s.name                  = "RJWebView"
   s.version               = "0.2.0"
-  s.summary               = "A short description of RJWebView."
-  s.description           = <<-DESC
-                            DESC
+  s.summary               = "This's a integration of WKWebView and UIWebView"
+  s.description           = "This's a integration of WKWebView and UIWebView"
 
   s.homepage              = "https://github.com/yirenjun/RJWebView"
   s.license               = 'MIT'


### PR DESCRIPTION
Cocoapod v1.2.1 will case error when run 'pod install' command in terminal in a new project like this:

[!] The `RJWebView` pod failed to validate due to 1 error.
[!] The validator for Swift projects uses Swift 3.0 by default, if you are using a different version of swift you can use a `.swift-version` file to set the version for your Pod. For example to use Swift 2.3, run: 
    `echo "2.3" > .swift-version`:
    - WARN  | summary: The summary is not meaningful.
    - ERROR | description: The description is empty.
